### PR TITLE
fix: Align ruler tool origin with mouse pointer on canvas

### DIFF
--- a/src/MapViewer/Index.jsx
+++ b/src/MapViewer/Index.jsx
@@ -51,10 +51,10 @@ function MapViewer({ type, src }) {
     } else if (rulerActive && fogCanvasRef.current) {
       const rect = fogCanvasRef.current.getBoundingClientRect();
       setRulerStart({
-        x: event.clientX - rect.left,
-        y: event.clientY - rect.top,
+        x: (event.clientX - rect.left) / scale,
+        y: (event.clientY - rect.top) / scale,
       });
-      setRulerEnd(null); // Reset ruler end point
+      setRulerEnd(null);
     }
   };
 
@@ -64,8 +64,8 @@ function MapViewer({ type, src }) {
       const fogCanvas = fogCanvasRef.current;
       const fogCtx = fogCanvas.getContext("2d");
       const rect = fogCanvas.getBoundingClientRect();
-      const x = event.clientX - rect.left;
-      const y = event.clientY - rect.top;
+      const x = (event.clientX - rect.left) / scale;
+      const y = (event.clientY - rect.top) / scale;
 
       fogCtx.globalCompositeOperation =
         fogMode === "erase" ? "destination-out" : "source-over";
@@ -76,8 +76,8 @@ function MapViewer({ type, src }) {
     } else if (rulerActive && rulerStart && fogCanvasRef.current) {
       const rect = fogCanvasRef.current.getBoundingClientRect();
       setRulerEnd({
-        x: event.clientX - rect.left,
-        y: event.clientY - rect.top,
+        x: (event.clientX - rect.left) / scale,
+        y: (event.clientY - rect.top) / scale,
       });
       drawTemporaryLine();
     }


### PR DESCRIPTION
* Adjust mouse coordinates in handleMouseDown and handleMouseMove to account for canvas scaling.

* Divide event.clientX and event.clientY by the scale factor to ensure accurate alignment of the ruler tool's origin with the mouse pointer.

You were very close, and I did not have to do much. When working with canvas elements, always calculate positions based on the size and scale of the canvas.